### PR TITLE
Adds support for multiple network interfaces

### DIFF
--- a/multi_ifcfg/README.md
+++ b/multi_ifcfg/README.md
@@ -1,0 +1,44 @@
+Overview
+========
+
+Heat templates in this directory are for implementations using
+multiple network interfaces. The template creates a second Linux
+bridge (kbr1) that connects to eth1 of Kubernetes minions.
+The IP address of eth1 is moved to the kbr1 bridge. This allows
+eth1 to bridge traffic between the virtual and physical network.
+
+Since Kubernetes does not support multiple network interfaces on pods,
+the template installs docker-spotter and pipework to manage a second
+interface (eth1) on pods that include the CONFIG_NETWORK=true
+ENV variable.
+
+Since Neutron drops packets from unknown MAC addresses, traffic from
+and behind the kbr1 bridge is block by security-groups. You can
+flush iptables or apply the following port security extension patch:
+
+https://review.openstack.org/#/c/126552/
+
+The following new parameters have been introduced:
+
+external_bridge_address_base specifies the first 3 octets of the
+external Neutron network used to provide connectivity to kbr1
+and eth1 of pods. Note: At this time, the external network must
+be a /24.
+
+Example: external_bridge_address_base: 192.168.225
+
+container_external_network_id is the UUID of the Neutron network
+used to provide external connectivity to containers. This network
+should be associated to external_bridge_address_base and
+container_external_subnet_id. Used to connect to minion and
+container eth1
+
+Example: container_external_network_id: be0eac49-f53e-43bc-b40c-d515f9ee2953
+
+container_external_subnet_id is the UUID of the Neutron network
+use to provide external connectivity to containers. This network
+should be associated to external_bridge_address_base and
+container_external_subnet_id. Used to connect to minion and
+container eth1
+
+Example: container_external_subnet_id: 005f6149-2e8c-42b0-9a5d-b0100979ac53

--- a/multi_ifcfg/kubecluster.yaml
+++ b/multi_ifcfg/kubecluster.yaml
@@ -1,0 +1,253 @@
+heat_template_version: 2013-05-23
+
+description: >
+  This template will boot a Kubernetes cluster with one or more
+  minions (as specified by the number_of_minions parameter, which
+  defaults to "2").
+
+parameters:
+
+  #
+  # REQUIRED PARAMETERS
+  #
+  ssh_key_name:
+    type: string
+    description: name of ssh key to be provisioned on our server
+
+  external_network_id:
+    type: string
+    description: uuid of a network to use for kube host floating ip addresses
+
+  container_external_network_id:
+    type: string
+    description: uuid of a network to use for container floating ip addresses
+
+  # Note: This network should be a /24 due to external_bridge_address_base
+  container_external_subnet_id:
+    type: string
+    description: uuid of a subnet to use for container floating ip addresses
+
+  external_bridge_address_base:
+    type: string
+    description: >
+      first three octets of the container external Neutron subnet used for
+      container floating-ip addresses. Ex> 151.16.182 Note: Should be a /24 network.
+
+  #
+  # OPTIONAL PARAMETERS
+  #
+  server_image:
+    type: string
+    default: fedora-20-x86_64
+    description: glance image used to boot the server
+
+  server_flavor:
+    type: string
+    default: m1.small
+    description: flavor to use when booting the server
+
+  dns_nameserver:
+    type: string
+    description: address of a dns nameserver reachable in your environment
+    default: 8.8.8.8
+
+  number_of_minions:
+    type: string
+    description: how many kubernetes minions to spawn
+    default: 1
+  
+  fixed_network_cidr:
+    type: string
+    description: network range for fixed ip network
+    default: 10.0.0.0/24
+
+resources:
+
+  master_wait_handle:
+    type: "AWS::CloudFormation::WaitConditionHandle"
+
+  master_wait_condition:
+    type: "AWS::CloudFormation::WaitCondition"
+    depends_on:
+      - kube_master
+    properties:
+      Handle:
+        get_resource: master_wait_handle
+      Timeout: "6000"
+
+  linkmanager_key:
+    type: "OS::Heat::RandomString"
+
+  ######################################################################
+  #
+  # network resources.  allocate a network and router for our server.
+  # it would also be possible to take advantage of existing network
+  # resources (and have the deployer provide network and subnet ids,
+  # etc, as parameters), but I wanted to minmize the amount of
+  # configuration necessary to make this go.
+  fixed_network:
+    type: "OS::Neutron::Net"
+
+  # This is the subnet on which we will deploy our server.
+  fixed_subnet:
+    type: "OS::Neutron::Subnet"
+    properties:
+      cidr: {get_param: fixed_network_cidr}
+      network_id:
+        get_resource: fixed_network
+      dns_nameservers:
+        - get_param: dns_nameserver
+
+  # create a router attached to the external network provided as a
+  # parameter to this stack.
+  extrouter:
+    type: "OS::Neutron::Router"
+    properties:
+      external_gateway_info:
+        network:
+          get_param: external_network_id
+
+  # attached fixed_subnet to our extrouter router.
+  extrouter_inside:
+    type: "OS::Neutron::RouterInterface"
+    properties:
+      router_id:
+        get_resource: extrouter
+      subnet_id:
+        get_resource:
+          fixed_subnet
+
+  ######################################################################
+  #
+  # security groups.  we need to permit network traffic of various
+  # sorts.
+  #
+
+  secgroup_base:
+    type: "OS::Neutron::SecurityGroup"
+    properties:
+      rules:
+        - protocol: icmp
+        - protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+
+  secgroup_kubernetes:
+    type: "OS::Neutron::SecurityGroup"
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 8080
+          port_range_max: 8080
+        - protocol: tcp
+          port_range_min: 4001
+          port_range_max: 4001
+        - protocol: tcp
+          port_range_min: 7001
+          port_range_max: 7001
+
+  ######################################################################
+  #
+  # databases server.  this sets up a Kubernetes server
+  #
+  kube_master:
+    type: "OS::Nova::Server"
+    depends_on:
+      - extrouter_inside
+    properties:
+      image:
+        get_param: server_image
+      flavor:
+        get_param: server_flavor
+      key_name:
+        get_param: ssh_key_name
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #!/bin/sh
+
+            yum -y upgrade
+            yum -y install jq dnf dnf-plugins-core
+            dnf -y copr enable walters/atomic-next
+            dnf -y copr enable larsks/fakedocker
+
+            sed -i 's/$releasever/21/g' /etc/yum.repos.d/_copr_walters-atomic-next.repo
+
+            yum -y install kubernetes
+
+            sed -i '
+              /^KUBE_API_ADDRESS=/ s/=.*/="0.0.0.0"/
+              /^MINION_ADDRESSES=/ s/=.*/="$MINION_ADDRESSES"/
+            ' /etc/kubernetes/apiserver
+
+            for service in etcd kube-apiserver kube-scheduler kube-controller-manager; do
+              systemctl enable $service
+              systemctl start $service
+            done
+
+            cfn-signal -e0 --data 'OK' -r 'Setup complete' '$WAIT_HANDLE'
+          params:
+            # NB: For this to work you need a version of Heat that
+            # includes https://review.openstack.org/#/c/121139/
+            "$MINION_ADDRESSES": {"Fn::Join": [",", {get_attr: [kube_minions, kube_node_ip_eth0]}]}
+            "$WAIT_HANDLE":
+              get_resource: master_wait_handle
+      networks:
+        - port:
+            get_resource: kube_master_eth0
+
+  kube_master_eth0:
+    type: "OS::Neutron::Port"
+    properties:
+      network_id:
+        get_resource: fixed_network
+      security_groups:
+        - get_resource: secgroup_base
+        - get_resource: secgroup_kubernetes
+      fixed_ips:
+        - subnet_id:
+            get_resource: fixed_subnet
+
+  kube_master_floating:
+    type: "OS::Neutron::FloatingIP"
+    depends_on:
+      - extrouter_inside
+    properties:
+      floating_network_id:
+        get_param: external_network_id
+      port_id:
+        get_resource: kube_master_eth0
+
+  kube_minions:
+    type: "OS::Heat::ResourceGroup"
+    depends_on:
+      - extrouter_inside
+    properties:
+      count: {get_param: number_of_minions}
+      resource_def:
+        type: kubenode.yaml
+        properties:
+          ssh_key_name: {get_param: ssh_key_name}
+          server_image: {get_param: server_image}
+          server_flavor: {get_param: server_flavor}
+          fixed_network_id: {get_resource: fixed_network}
+          fixed_subnet_id: {get_resource: fixed_subnet}
+          kube_master_ip: {get_attr: [kube_master_eth0, fixed_ips, 0, ip_address]}
+          external_network_id: {get_param: external_network_id}
+          external_bridge_address_base: {get_param: external_bridge_address_base}
+          container_external_network_id: {get_param: container_external_network_id}
+          container_external_subnet_id: {get_param: container_external_subnet_id}
+          linkmanager_key: {get_attr: [linkmanager_key, value]}
+
+outputs:
+
+  kube_master:
+    value: {get_attr: [kube_master_floating, floating_ip_address]}
+
+  kube_minions:
+    value: {get_attr: [kube_minions, kube_node_ip_eth0]}
+
+  kube_minions_external:
+    value: {get_attr: [kube_minions, kube_node_external_ip]}
+

--- a/multi_ifcfg/kubenode.yaml
+++ b/multi_ifcfg/kubenode.yaml
@@ -1,0 +1,330 @@
+heat_template_version: 2013-05-23
+
+description: >
+  This is a nested stack that defines a single Kubernetes minion,
+  based on a vanilla Fedora 20 cloud image.  This stack is included by
+  a ResourceGroup resource in the parent template (kubecluster.yaml).
+
+parameters:
+
+  server_image:
+    type: string
+    default: fedora-20-x86_64-updated
+    description: glance image used to boot the server
+
+  server_flavor:
+    type: string
+    default: m1.small
+    description: flavor to use when booting the server
+
+  ssh_key_name:
+    type: string
+    description: name of ssh key to be provisioned on our server
+    default: lars
+
+  external_network_id:
+    type: string
+    description: uuid of a network to use for kube host floating ip addresses
+
+  container_external_network_id:
+    type: string
+    description: uuid of a network to use for container floating ip addresses
+
+  container_external_subnet_id:
+    type: string
+    description: uuid of a subnet to use for container floating ip addresses
+
+  bridge_address_base:
+    type: string
+    description: >
+      first two octets of a /16 network to use for minion
+      addresses.
+    default: 10.251
+
+  external_bridge_address_base:
+    type: string
+    description: >
+      first three octets of the container external subnet Neutron network used for
+      container floating-ip addresses. Note: Should be a /24 network.
+
+  linkmanager_key:
+    type: string
+    description: >
+      used to sign etcd keys that control vxlan
+      overlay network.
+
+  # The following are all generated in the parent template.
+  kube_master_ip:
+    type: string
+    description: IP address of the Kubernetes master server.
+  fixed_network_id:
+    type: string
+    description: Network from which to allocate fixed addresses.
+  fixed_subnet_id:
+    type: string
+    description: Subnet from which to allocate fixed addresses.
+
+resources:
+
+  node_wait_handle:
+    type: "AWS::CloudFormation::WaitConditionHandle"
+
+  node_wait_condition:
+    type: "AWS::CloudFormation::WaitCondition"
+    depends_on:
+      - kube_node
+    properties:
+      Handle:
+        get_resource: node_wait_handle
+      Timeout: "6000"
+
+  # I am lazy, so this opens up all ports.
+  secgroup_all_open:
+    type: "OS::Neutron::SecurityGroup"
+    properties:
+      rules:
+        - protocol: icmp
+        - protocol: tcp
+        - protocol: udp
+
+  kube_node:
+    type: "OS::Nova::Server"
+    properties:
+      image:
+        get_param: server_image
+      flavor:
+        get_param: server_flavor
+      key_name:
+        get_param: ssh_key_name
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #!/bin/sh
+
+            setenforce 0
+            sed -i '/^SELINUX=/ s/=.*/=permissive/' /etc/selinux/config
+
+            bridge_address_base="$BRIDGE_ADDRESS_BASE"
+            external_bridge_address_base="$EXTERNAL_BRIDGE_ADDRESS_BASE"
+
+            yum -y remove NetworkManager
+            chkconfig network on
+
+            # enable dnf command
+            yum -y install dnf-plugins-core
+
+            # enable kubernetes repository
+            dnf -y copr enable walters/atomic-next
+            sed -i 's/$releasever/21/g' /etc/yum.repos.d/_copr_walters-atomic-next.repo
+
+            # avoid conflicts with "docker" package in fedora 20 that is not
+            # the docker you are looking for.
+            dnf -y copr enable larsks/fakedocker
+
+            yum -y upgrade
+            yum -y install \
+              jq openvswitch bridge-utils docker-io ebtables \
+              git python-netifaces python-requests which \
+              tcpdump python-netifaces python-setuptools \
+              golang-github-docker-libcontainer kubernetes \
+
+            # this is required to implement "exec" type livenessProbes in
+            # kubernetes.
+            ln -s /usr/bin/nsinit /usr/sbin/nsinit
+
+            my_eth0_ip=$(ip addr show eth0 | awk '$1 == "inet" {print $2}' | cut -f1 -d/)
+            my_eth1_ip=$(ip addr show eth1 | awk '$1 == "inet" {print $2}' | cut -f1 -d/)
+            my_eth0_ip_last_octet=${my_eth0_ip##*.}
+            bridge_address="${bridge_address_base}.${my_eth0_ip_last_octet}.1"
+            external_bridge_address="${my_eth1_ip}"
+            netconf=/etc/sysconfig/network-scripts
+
+            # Docker contains are attached to this bridge
+            cat > $netconf/ifcfg-kbr0 <<EOF
+            DEVICE=kbr0
+            TYPE=Bridge
+            IPADDR=${bridge_address}
+            NETMASK=255.255.255.0
+            ONBOOT=yes
+            STP=yes
+
+            # With the default forwarding delay of 15 seconds,
+            # many operations in a 'docker build' will simply timeout
+            # before the bridge starts forwarding.
+            DELAY=2
+            EOF
+
+            # This bridge will handle VXLAN tunnels
+            cat > $netconf/ifcfg-obr0 <<EOF
+            DEVICE=obr0
+            DEVICETYPE=ovs
+            TYPE=OVSBridge
+            ONBOOT=yes
+            BRIDGE=kbr0
+            STP=true
+            EOF
+
+            # External container network bridge
+            cat > $netconf/ifcfg-kbr1 <<EOF
+            DEVICE=kbr1
+            TYPE=Bridge
+            IPADDR=${external_bridge_address}
+            NETMASK=255.255.255.0
+            ONBOOT=yes
+            STP=yes
+            BOOTPROTO=none
+            EOF
+
+            # Physcial interface used to bridge container floating-ips
+            cat > $netconf/ifcfg-eth1 <<EOF
+            DEVICE=eth1
+            BOOTPROTO=none
+            ONBOOT=yes
+            DEFROUTE=no
+            TYPE=Ethernet
+            EOF
+
+            cat > $netconf/route-kbr0 <<EOF
+            ${bridge_address_base}.0.0/16 dev kbr0 scope link src ${bridge_address}
+            EOF
+
+            # Container interface MTU must be reduced in order to
+            # prevent fragmentation problems when vxlan header is
+            # added to a host-MTU sized packet.
+            cat > /etc/sysconfig/docker <<EOF
+            OPTIONS="--selinux-enabled -b kbr0 --mtu 1450"
+            EOF
+
+            sed -i '/^KUBE_ETCD_SERVERS=/ s|=.*|=http://$KUBE_MASTER_IP:4001|' \
+              /etc/kubernetes/config
+            sed -i '
+              /^MINION_ADDRESS=/ s/=.*/="0.0.0.0"/
+              /^MINION_HOSTNAME=/ s/=.*/="'"$my_eth0_ip"'"/
+            ' /etc/kubernetes/kubelet
+
+            sed -i '
+              /^KUBE_API_ADDRESS=/ s/=.*/="$KUBE_MASTER_IP"/
+              /^KUBE_MASTER=/ s/=.*/="$KUBE_MASTER_IP"/
+            ' /etc/kubernetes/apiserver
+
+            # install linkmanager for managing OVS links
+            # for minion overlay network.
+            git clone http://github.com/larsks/linkmanager.git \
+              /opt/linkmanager
+            (
+              cd /opt/linkmanager
+              python setup.py install
+              cp linkmanager.service /etc/systemd/system/linkmanager.service
+            )
+            cat > /etc/sysconfig/linkmanager <<EOF
+            OPTIONS="-s http://$KUBE_MASTER_IP:4001 -v -b obr0 --secret $LINKMANAGER_KEY"
+            EOF
+
+            cat >> /etc/environment <<EOF
+            KUBERNETES_MASTER=http://$KUBE_MASTER_IP:8080
+            EOF
+
+            # Install pipework and docker-spotter for managing eth1 of containers
+            git clone http://github.com/danehans/docker-spotter.git \
+              /opt/docker-spotter
+            (
+              cd /opt/docker-spotter
+              curl -s https://go.googlecode.com/files/go1.2.linux-amd64.tar.gz \
+              | tar -C /usr/local -xzf -
+              export PATH=/usr/local/go/bin:$PATH
+              export GOPATH=/go
+              go get -d && go build
+              cp docker-spotter /usr/bin/docker-spotter
+              cp docker-spotter.service /etc/systemd/system/docker-spotter.service
+            )
+
+            cat > /etc/sysconfig/docker-spotter <<EOF
+            OPTIONS=-e CONFIG_NETWORK=true:start,restart:pipework:kbr1:{{.ID}}:0/0 \
+            -e CONFIG_NETWORK=true:stop:echo:gone
+            EOF
+
+            git clone http://github.com/danehans/pipework /opt/pipework
+            cp /opt/pipework/pipework /usr/bin/pipework
+
+            # start bridges first
+            systemctl enable openvswitch
+            systemctl start openvswitch
+            ifup kbr0
+            ifup obr0
+            ifdown eth1
+            ifup eth1
+            ifup kbr1
+
+            # add eth1 to kube external bridge
+            brctl addif kbr1 eth1
+
+            # then other services
+            for service in docker.socket kubelet kube-proxy linkmanager docker-spotter; do
+              systemctl enable $service
+              systemctl start $service
+            done
+
+            # make fedora user a member of the docker group
+            # (so you can run docker commands as the fedora user)
+            usermod -G docker fedora
+
+            cfn-signal -e0 --data 'OK' -r 'Setup complete' '$WAIT_HANDLE'
+          params:
+            "$KUBE_MASTER_IP":
+              get_param: kube_master_ip
+            "$BRIDGE_ADDRESS_BASE":
+              get_param: bridge_address_base
+            "$EXTERNAL_BRIDGE_ADDRESS_BASE":
+              get_param: external_bridge_address_base
+            "$LINKMANAGER_KEY":
+              get_param: linkmanager_key
+            "$WAIT_HANDLE":
+              get_resource: node_wait_handle
+      networks:
+        - port:
+            get_resource: kube_node_eth0
+        - port:
+            get_resource: kube_node_eth1
+
+  kube_node_eth1:
+    type: "OS::Neutron::Port"
+    properties:
+      network_id:
+        get_param: container_external_network_id
+      security_groups:
+        - get_resource: secgroup_all_open
+      fixed_ips:
+        - subnet_id:
+            get_param: container_external_subnet_id
+
+  kube_node_eth0:
+    type: "OS::Neutron::Port"
+    properties:
+      network_id:
+        get_param: fixed_network_id
+      security_groups:
+        - get_resource: secgroup_all_open
+      fixed_ips:
+        - subnet_id:
+            get_param: fixed_subnet_id
+
+  kube_node_floating:
+    type: "OS::Neutron::FloatingIP"
+    properties:
+      floating_network_id:
+        get_param: external_network_id
+      port_id:
+        get_resource: kube_node_eth0
+
+outputs:
+
+  kube_node_ip_eth0:
+    value: {get_attr: [kube_node_eth0, fixed_ips, 0, ip_address]}
+
+  kube_node_ip_eth1:
+    value: {get_attr: [kube_node_eth1, fixed_ips, 0, ip_address]}
+
+  kube_node_external_ip:
+    value: {get_attr: [kube_node_floating, floating_ip_address]}
+


### PR DESCRIPTION
Previously, containers could only have a single network interface.
This patch allows the kube infra to support multiple interfaces
on containers. docker-spotter runs on minions and connects to the
docker daemon, receives events and executes commands on the CLI.
In our use case, docker-spotter issues a pipework command to
connect/disconnect eth1 of containers (with a name nova-network)
to the container external neutron network:

Connection pattern:
container_eth1<>kbr-ex<>kube_eth1<>neutron_ext_net
