### PR TITLE
Make heat-kubernetes operate with kubernetes 0.6.z

### DIFF
--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -152,6 +152,7 @@ resources:
           template: |
             #!/bin/sh
 
+            setenforce permissive
             yum -y upgrade
             yum -y install jq dnf dnf-plugins-core
             dnf -y copr enable walters/atomic-next
@@ -162,9 +163,11 @@ resources:
             yum -y install kubernetes
 
             sed -i '
-              /^KUBE_API_ADDRESS=/ s/=.*/="0.0.0.0"/
-              /^MINION_ADDRESSES=/ s/=.*/="$MINION_ADDRESSES"/
+              /^KUBE_API_ADDRESS=/ s/=.*/="-address=0.0.0.0"/
             ' /etc/kubernetes/apiserver
+            sed -i '
+              /^KUBELET_ADDRESSES=/ s/=.*/="--machines=$MINION_ADDRESSES"/
+            ' /etc/kubernetes/controller-manager
 
             for service in etcd kube-apiserver kube-scheduler kube-controller-manager; do
               systemctl enable $service

--- a/kubenode.yaml
+++ b/kubenode.yaml
@@ -159,17 +159,12 @@ resources:
             OPTIONS="--selinux-enabled -b kbr0 --mtu 1450"
             EOF
 
-            sed -i '/^KUBE_ETCD_SERVERS=/ s|=.*|=http://$KUBE_MASTER_IP:4001|' \
+            sed -i '/^KUBE_ETCD_SERVERS=/ s|=.*|=--etcd_servers=http://$KUBE_MASTER_IP:4001|' \
               /etc/kubernetes/config
             sed -i '
-              /^MINION_ADDRESS=/ s/=.*/="0.0.0.0"/
-              /^MINION_HOSTNAME=/ s/=.*/="'"$myip"'"/
+              /^KUBELET_ADDRESS=/ s/=.*/="--address=0.0.0.0"/
+              /^KUBELET_HOSTNAME=/ s/=.*/="--hostname_override='"$myip"'"/
             ' /etc/kubernetes/kubelet
-
-            sed -i '
-              /^KUBE_API_ADDRESS=/ s/=.*/="$KUBE_MASTER_IP"/
-              /^KUBE_MASTER=/ s/=.*/="$KUBE_MASTER_IP"/
-            ' /etc/kubernetes/apiserver
 
             # install linkmanager for managing OVS links
             # for minion overlay network.


### PR DESCRIPTION
The existing code base does not operate with the latest fedora release of
kubernetes 0.6.z.  This patch fixes that problem.
