### PR TITLE
Set port replacement_policy to AUTO

### DIFF
--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -276,6 +276,7 @@ resources:
       fixed_ips:
         - subnet_id:
             get_resource: fixed_subnet
+      replacement_policy: AUTO
 
   kube_master_floating:
     type: "OS::Neutron::FloatingIP"

--- a/kubenode.yaml
+++ b/kubenode.yaml
@@ -193,6 +193,7 @@ resources:
       fixed_ips:
         - subnet_id:
             get_param: fixed_subnet_id
+      replacement_policy: AUTO
 
   kube_node_floating:
     type: "OS::Neutron::FloatingIP"


### PR DESCRIPTION
The default replacement_policy is REPLACE_ALWAYS, which means a stack update
will always replace the port regardless of any property changes. As a result,
all the VMs of the kubecluster will be replaced, which is undesired.