### PR TITLE
Allow specification docker volume size

### DIFF
--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -26,6 +26,11 @@ parameters:
     default: centos-atomic
     description: glance image used to boot the server
 
+  master_flavor:
+    type: string
+    default: m1.small
+    description: flavor to use when booting the server
+
   server_flavor:
     type: string
     default: m1.small
@@ -270,7 +275,7 @@ resources:
       image:
         get_param: server_image
       flavor:
-        get_param: server_flavor
+        get_param: master_flavor
       key_name:
         get_param: ssh_key_name
       user_data_format: RAW

--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -79,6 +79,13 @@ parameters:
     constraints:
       - allowed_values: ["true", "false"]
 
+  docker_volume_size:
+    type: string
+    description: >
+      size of a cinder volume to allocate to docker for container/image
+      storage
+    default: 25
+
 resources:
 
   master_wait_handle:
@@ -312,6 +319,7 @@ resources:
           kube_master_ip: {get_attr: [kube_master_eth0, fixed_ips, 0, ip_address]}
           external_network_id: {get_param: external_network_id}
           kube_allow_priv: {get_param: kube_allow_priv}
+          docker_volume_size: {get_param: docker_volume_size}
 
 outputs:
 


### PR DESCRIPTION
Pass through docker_volume_size to the kubenode from kubecluster
template.