### PR TITLE
Support dynamically add/remove minion

### DIFF
--- a/fragments/configure-kubernetes-master.sh
+++ b/fragments/configure-kubernetes-master.sh
@@ -14,6 +14,6 @@ sed -i '
 ' /etc/kubernetes/apiserver
 
 sed -i '
-  /^KUBELET_ADDRESSES=/ s/=.*/="--machines='"$MINION_ADDRESSES"'"/
+  /^KUBELET_ADDRESSES=/ s/=.*/="--machines='""'"/
 ' /etc/kubernetes/controller-manager
 

--- a/fragments/configure-kubernetes-minion.sh
+++ b/fragments/configure-kubernetes-minion.sh
@@ -29,3 +29,11 @@ sed -i '
 cat >> /etc/environment <<EOF
 KUBERNETES_MASTER=http://$KUBE_MASTER_IP:8080
 EOF
+
+cpu=$(expr $(nproc) \* 1000)
+memory_kb=$(cat /proc/meminfo | awk '/MemTotal: /{print $2}')
+memory=$(expr $memory_kb \* 1024)
+curl -sf -X POST -H 'Content-Type: application/json' \
+    --data-binary "{'kind':'Minion','id':'$myip','apiVersion':'v1beta1',
+        'resources':{'capacity':{'cpu':$cpu,'memory':$memory}}}" \
+    http://$KUBE_MASTER_IP:8080/api/v1beta1/minions

--- a/fragments/write-heat-params-master.yaml
+++ b/fragments/write-heat-params-master.yaml
@@ -5,7 +5,6 @@ write_files:
     owner: "root:root"
     permissions: "0644"
     content: |
-      MINION_ADDRESSES="$MINION_ADDRESSES"
       KUBE_ALLOW_PRIV="$KUBE_ALLOW_PRIV"
       WAIT_HANDLE="$WAIT_HANDLE"
       FLANNEL_NETWORK_CIDR="$FLANNEL_NETWORK_CIDR"

--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -193,7 +193,6 @@ resources:
         str_replace:
           template: {get_file: fragments/write-heat-params-master.yaml}
           params:
-            "$MINION_ADDRESSES": {"Fn::Join": [",", {get_attr: [kube_minions, kube_node_ip]}]}
             "$KUBE_ALLOW_PRIV": {get_param: kube_allow_priv}
             "$WAIT_HANDLE": {get_resource: master_wait_handle}
             "$FLANNEL_NETWORK_CIDR": {get_param: flannel_network_cidr}
@@ -311,6 +310,7 @@ resources:
     type: "OS::Heat::ResourceGroup"
     depends_on:
       - extrouter_inside
+      - master_wait_condition
     properties:
       count: {get_param: number_of_minions}
       resource_def:


### PR DESCRIPTION
Currently, the list of minions is statically specified in master node,
and the list of IP addresses of minion nodes is passed to master node
through user_data. This approach doesn't work well on scaling. For example,
adding a minion node through stack-update will cause an update on user_data,
which cause the master node to be replaced.

This commit addresses this issue by dynamically register minion node.
There are two cases:
* Scale out: the new minion nodes will register themselves to the cluster
  when they are booting.
* Scale in: a subset of minion nodes are deleted by Heat, and the
  master node will discover it and automatically deregister the
  deleted nodes.