### PR TITLE
Add user to dockerroot group instead of docker

### DIFF
--- a/fragments/add-to-docker-group.sh
+++ b/fragments/add-to-docker-group.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-# Under atomic, we need to make sure the 'docker' group exists in 
+# Under atomic, we need to make sure the 'dockerroot' group exists in
 # /etc/group (because /lib/group cannot be modified by usermod).
-echo "making 'docker' group editable"
-if ! grep -q docker /etc/group; then
-	grep docker /lib/group >> /etc/group
+echo "making 'dockerroot' group editable"
+if ! grep -q dockerroot /etc/group; then
+	grep dockerroot /lib/group >> /etc/group
 fi
 
-# make 'minion' user a member of the docker group
+# make 'minion' user a member of the dockerroot group
 # (so you can run docker commands as the 'minion' user)
-echo "adding 'minion' user to 'docker' group"
-usermod -G docker minion
+echo "adding 'minion' user to 'dockerroot' group"
+usermod -G dockerroot minion
 


### PR DESCRIPTION
The script for adding user to dcoker group would fail, since there
is no group with name 'docker' in current version of atomic image.
Use 'dockerroot' instead.