### PR TITLE
Fix a wrong option for starting kubelet

### DIFF
--- a/fragments/configure-kubernetes-minion.sh
+++ b/fragments/configure-kubernetes-minion.sh
@@ -16,6 +16,7 @@ sed -i '
 sed -i '
 /^KUBELET_ADDRESS=/ s/=.*/="--address=0.0.0.0"/
 /^KUBELET_HOSTNAME=/ s/=.*/="--hostname_override='"$myip"'"/
+/^KUBELET_API_SERVER=/ s/=.*/="--api_servers='"$KUBE_MASTER_IP"':8080"/
 ' /etc/kubernetes/kubelet
 
 sed -i '


### PR DESCRIPTION
The default kubenetes kubelet config file specified a wrong option.
At the file /etc/kubernetes/kubelet, it specified:
"--api_server=127.0.0.1:8080"
First, the flag should be "--api_servers". Second, it should use
the IP address of the master node instead of "127.0.0.1".

See: https://bugzilla.redhat.com/show_bug.cgi?id=1200924